### PR TITLE
Manually write binding for Surface.getCapabilities

### DIFF
--- a/codegen/patches.ts
+++ b/codegen/patches.ts
@@ -1,3 +1,5 @@
+import { pyList } from "./pygen";
+
 function listFeatures(className: string): string[] {
   const rawFFIFunc = `wgpu${className}EnumerateFeatures`;
   return [
@@ -10,21 +12,50 @@ function listFeatures(className: string): string[] {
   ];
 }
 
-function notImplemented(name: string): string[] {
-  return [
-    `# ${name} is not implemented`,
-    `# def ${name}(...):`,
-    ``
-  ];
+function commentedOut(name: string, msg: string): string[] {
+  return [`# ${name}: ${msg}`, `# def ${name}(...):`, ``];
 }
 
 export const FORCE_NULLABLE_ARGS: Set<string> = new Set([
   "wrappedSubmissionIndex",
 ]);
 
+const SURFACE_CAPS = `
+class SurfaceCapabilities:
+    def __init__(self, formats: ${pyList("TextureFormat")}, presentModes: ${pyList("PresentMode")}, alphaModes: ${pyList("CompositeAlphaMode")}):
+        self.formats = formats
+        self.presentModes = presentModes
+        self.alphaModes = alphaModes
+`.trim();
+
+export const PATCHED_CLASSES: Map<string, string> = new Map([
+  ["WGPUSurfaceCapabilities", SURFACE_CAPS],
+]);
+
+const SURFACE_GET_CAPS = `
+def getCapabilities(self, adapter: "Adapter") -> "SurfaceCapabilities":
+    # Hand-written because the usage pattern for this is ridiculous
+    # (it sets raw pointers onto a struct you provide, and you're
+    #  expected to free these arrays with a special function)
+    caps = ffi.new("WGPUSurfaceCapabilities *")
+    lib.wgpuSurfaceGetCapabilities(self._cdata, adapter._cdata, caps)
+    formats = [TextureFormat(caps.formats[idx]) for idx in range(caps.formatCount)]
+    present_modes = [PresentMode(caps.presentModes[idx]) for idx in range(caps.presentModeCount)]
+    alpha_modes = [CompositeAlphaMode(caps.alphaModes[idx]) for idx in range(caps.alphaModeCount)]
+    # Note! This free function takes the caps struct *by value*, hence
+    # the usage of caps[0] to 'dereference' it. Yes this is weird!
+    lib.wgpuSurfaceCapabilitiesFreeMembers(caps[0])
+    return SurfaceCapabilities(formats, present_modes, alpha_modes)
+`
+  .trim()
+  .split("\n");
+
 export const PATCHED_FUNCTIONS: Map<string, string[]> = new Map([
   ["wgpuAdapterEnumerateFeatures", listFeatures("Adapter")],
   ["wgpuDeviceEnumerateFeatures", listFeatures("Device")],
-  ["wgpuSurfaceGetCapabilities", notImplemented("GetCapabilities")]
+  ["wgpuSurfaceGetCapabilities", SURFACE_GET_CAPS],
+  [
+    "wgpuSurfaceCapabilitiesFreeMembers",
+    commentedOut("FreeMembers", "Not needed"),
+  ],
 ]);
-

--- a/codegen/pygen.ts
+++ b/codegen/pygen.ts
@@ -1,0 +1,24 @@
+import { recase, removePrefix } from "./stringmanip";
+
+export const IS_PY12 = false;
+
+
+export function pyOptional(pyType: string): string {
+  return IS_PY12 ? `${pyType} | None` : `Optional[${pyType}]`;
+}
+
+export function pyUnion(...args: string[]): string {
+  return IS_PY12 ? args.join(" | ") : `Union[${args.join(", ")}]`;
+}
+
+export function pyList(pyType: string): string {
+  return IS_PY12 ? `list[${pyType}]` : `List[${pyType}]`;
+}
+
+export function toPyName(ident: string, isClass = false): string {
+  return recase(removePrefix(ident, ["WGPU", "wgpu"]), isClass);
+}
+
+export function pyBool(b?: boolean): string {
+  return b ? "True" : "False";
+}

--- a/examples/triangle_windowed.py
+++ b/examples/triangle_windowed.py
@@ -59,6 +59,15 @@ def main():
     (adapter, _) = get_adapter(instance, xg.PowerPreference.HighPerformance, surface)
     device = XDevice(get_device(adapter))
 
+    # Lets list some capabilities of this surface
+    surf_caps = surface.getCapabilities(adapter)
+    print("==== Surface Caps ====")
+    print("Formats:", ", ".join([fmt.name for fmt in surf_caps.formats]))
+    print("Present modes:", ", ".join([mode.name for mode in surf_caps.presentModes]))
+    print(
+        "Composite+alpha modes:", ", ".join([mode.name for mode in surf_caps.alphaModes])
+    )
+
     window_tex_format = xg.TextureFormat.BGRA8Unorm
     # surface.getPreferredFormat(adapter)
     print("Window tex format:", window_tex_format.name)
@@ -102,7 +111,6 @@ def main():
         command_encoder = device.createCommandEncoder()
 
         surf_tex = surface.getCurrentTexture2()
-        print("Tex status?", surf_tex.status.name)
 
         color_view = surf_tex.texture.createView(
             format=xg.TextureFormat.Undefined,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xgpu"
-version = "0.2.0"
+version = "0.3.0"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = ["cffi"]


### PR DESCRIPTION
The C usage pattern for this function is idiosyncratic: 
you're expected to create a `WGPUSurfaceCapabilities`, pass a pointer to it to `wgpuSurfaceGetCapabilities(...)`, 
which then sets internal pointers to arrays along with their element counts.

You do not own these arrays, instead when you're done you're expected to
free them with a separate function `wgpuSurfaceCapabilitiesFreeMembers` which takes the capabilities
struct *by value* and frees the internal pointers.

This is the only function in the API that works remotely like this so the binding has to be hand-written.