### PR TITLE
check status of adapter before returning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xgpu"
-version = "0.5.0"
+version = "0.5.1"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = ["cffi"]
@@ -70,4 +70,4 @@ before-build = "pip install cffi && cd xgpu && python _build_ext.py"
 skip = ["*-win32", "*-manylinux_i686", "*musl*"]
 
 # just make sure the library imports for now
-test-command = 'python -c "import xgpu"'
+test-command = 'python -c "import xgpu; import xgpu.conveniences"'

--- a/xgpu/conveniences.py
+++ b/xgpu/conveniences.py
@@ -28,7 +28,7 @@ def get_adapter(
     power=xg.PowerPreference.HighPerformance,
     surface: Optional[xg.Surface] = None,
     timeout: float = 60.0,
-) -> tuple[XAdapter, xg.Instance]:
+) -> Tuple[XAdapter, xg.Instance]:
     """
     Get an adapter, blocking up to `timeout` seconds
     """

--- a/xgpu/conveniences.py
+++ b/xgpu/conveniences.py
@@ -73,7 +73,7 @@ def get_adapter(
 
 def get_device(
     adapter: xg.Adapter,
-    features: Optional[list[xg.FeatureName]] = None,
+    features: Optional[List[xg.FeatureName]] = None,
     limits: Optional[xg.RequiredLimits] = None,
     timeout: float = 60,
 ) -> XDevice:


### PR DESCRIPTION
- raise a `RuntimeError` if getting the adapter isn't successful
- import `xgpu.conveniences` in the tests to check during build