### PR TITLE
Use primary backend in get_instance

### DIFF
--- a/xgpu/helpers.py
+++ b/xgpu/helpers.py
@@ -12,9 +12,10 @@ def maybe_chain(item: Optional[xg.Chainable] = None) -> Optional[xg.ChainedStruc
 
 
 def get_instance(shader_debug=False, validation=False) -> xg.Instance:
-    extras = None
+    extras = xg.InstanceExtras()
+    extras.backends = xg.InstanceBackend.Primary
+
     if shader_debug or validation:
-        extras = xg.InstanceExtras()
         if shader_debug:
             extras.flags |= xg.InstanceFlag.Debug
         if validation:


### PR DESCRIPTION
GLES in the backtrace for #15 was suspicious since it should be using a vulkan backend. This PR does not fix the issue but does shorten the backtrace and remove GLES by switching the requested backend to `Primary` as described in https://github.com/gfx-rs/wgpu/issues/4650

```
_pthread_kill_implementation (no_tid=0, signo=6, threadid=140737350225920) at ./nptl/pthread_kill.c:44
44	./nptl/pthread_kill.c: No such file or directory.
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140737350225920)
    at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140737350225920) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737350225920, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff7c88476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff7c6e7f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff7ccf676 in __libc_message (action=action@entry=do_abort, 
    fmt=fmt@entry=0x7ffff7e21b77 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#6  0x00007ffff7ce6cfc in malloc_printerr (
    str=str@entry=0x7ffff7e245b8 "malloc_consolidate(): unaligned fastbin chunk detected")
    at ./malloc/malloc.c:5664
#7  0x00007ffff7ce798c in malloc_consolidate (av=av@entry=0x7ffff7e60c80 <main_arena>)
    at ./malloc/malloc.c:4750
#8  0x00007ffff7ce8ea0 in _int_free (av=0x7ffff7e60c80 <main_arena>, p=0x52939e0, 
    have_lock=<optimized out>) at ./malloc/malloc.c:4674
#9  0x00007ffff7ceb453 in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3391
#10 0x00007fff9ef036b5 in _ZN9hashbrown3raw21RawTable$LT$T$C$A$GT$14reserve_rehash17hfad243f24cf57058E.llvm.10908479499971756794 ()
   from /home/mikedh/venv/lib/python3.12/site-packages/xgpu/libwgpu_native.so
#11 0x00007fff9f01d982 in hashbrown::map::HashMap<K,V,S,A>::insert ()
   from /home/mikedh/venv/lib/python3.12/site-packages/xgpu/libwgpu_native.so
#12 0x00007fff9ef50dcc in wgpu_core::device::global::<impl wgpu_core::global::Global<G>>::bind_group_layout_drop () from /home/mikedh/venv/lib/python3.12/site-packages/xgpu/libwgpu_native.so
#13 0x00007fff9f04a9c3 in alloc::sync::Arc<T,A>::drop_slow ()
   from /home/mikedh/venv/lib/python3.12/site-packages/xgpu/libwgpu_native.so
#14 0x00007fff9efde193 in wgpuBindGroupLayoutRelease ()
   from /home/mikedh/venv/lib/python3.12/site-packages/xgpu/libwgpu_native.so
#15 0x00007fffa04d8a3f in _cffi_f_wgpuBindGroupLayoutRelease (self=<optimized out>, 
    arg0=<optimized out>) at _wgpu_native_cffi.c:5239
#16 0x000000000057dac9 in ?? ()
#17 0x000000000057ea2d in ?? ()
#18 0x00000000006409ee in PyObject_CallFunctionObjArgs ()
#19 0x00007fffa087967d in gcp_finalize (origobj=0x7fff964156b0, destructor=0x7fff96418310)
    at src/c/_cffi_backend.c:2018
#20 cdatagcp_finalize (cd=<optimized out>) at src/c/_cffi_backend.c:2047
#21 0x00000000005692e0 in ?? ()
#22 0x0000000000674680 in ?? ()
#23 0x0000000000660bac in Py_FinalizeEx ()
#24 0x000000000066db2e in Py_RunMain ()
#25 0x000000000062aa1d in Py_BytesMain ()
#26 0x00007ffff7c6fd90 in __libc_start_call_main (main=main@entry=0x62a960, argc=argc@entry=2, 
    argv=argv@entry=0x7fffffffbc28) at ../sysdeps/nptl/libc_start_call_main.h:58
#27 0x00007ffff7c6fe40 in __libc_start_main_impl (main=0x62a960, argc=2, argv=0x7fffffffbc28, 
    init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, 
    stack_end=0x7fffffffbc18) at ../csu/libc-start.c:392
#28 0x000000000062a895 in _start ()

```