### PR TITLE
fix possible segfault with callbacks

### DIFF
--- a/codegen/generate.ts
+++ b/codegen/generate.ts
@@ -1145,8 +1145,8 @@ def ${this.rawName()}(${rawArglist.join(", ")}):
 class ${this.func.pyName}:
     def __init__(self, callback: ${pytype}):
         self.index = ${mapName}.add(callback)
-        self._userdata = _ffi_new("int[]", 1)
-        self._userdata[0] = self.index
+        # Yes, we're just storing ints into pointers.
+        self._userdata = ffi.cast("void *", self.index)
         self._ptr = lib.${this.rawName()}
 
     def remove(self):
@@ -1424,7 +1424,7 @@ def _ffi_string(val) -> str:
         raise RuntimeError("IMPOSSIBLE")
 
 def _cast_userdata(ud: CData) -> int:
-    return ffi.cast("int *", ud)[0]
+    return ffi.cast("int", ud)
 
 class Chainable(ABC):
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xgpu"
-version = "0.6.3"
+version = "0.6.4"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = ["cffi"]


### PR DESCRIPTION
On the Python side, callbacks were creating their userdata (the `void *` passed to the callback) as a new CData of `int[1]` and then putting an index into that CData; when the Python-side callback object got GCed this CData would get released, and then the C/native side of things could have a `void *` to a released cdata.

E.g., consider a pattern like:
```python
def enable_logging(level: xg.LogLevel):
    def _log_cb(level: xg.LogLevel, msg: str):
        print(f"[{level.name}]: {msg}")

    xg.setLogCallback(xg.LogCallback(callback))
    xg.setLogLevel(level)
```

When this function returns, the `xg.LogCallback(callback)` object is garbage collected, so under the previous convention the CData it held would get released as well and then `wgpu-native` would have a dangling `void *`. Now, this object is still garbage collected but it doesn't matter since it's just a thin wrapper that doesn't make any C allocations.

Instead, now callback userdata is created by directly casting the int index into a void*, so an intermediate int[1] is no longer created.