### PR TITLE
Allow intentional leaking of wgpu objects

### DIFF
--- a/codegen/generate.ts
+++ b/codegen/generate.ts
@@ -1074,9 +1074,22 @@ class ${this.pyName}:
             self._cdata = ffi.NULL
 
     def release(self):
+        """ Call the underlying wgpu release function;
+            works even on leaked objects """
         if self._cdata == ffi.NULL:
             return
-        ffi.release(self._cdata)
+        ffi.gc(self._cdata, None)
+        lib.${releaser.name}(self._cdata)
+        #ffi.release(self._cdata)
+        self._cdata = ffi.NULL
+
+    def leak(self):
+        """ Prevent the underlying wgpu object from being
+        released when this Python object is garbage collected """
+        ffi.gc(self._cdata, None)
+
+    def invalidate(self):
+        """ Set this to a null pointer """
         self._cdata = ffi.NULL
 
     def isValid(self):

--- a/examples/glfw_window.py
+++ b/examples/glfw_window.py
@@ -9,12 +9,11 @@ import glfw
 import xgpu
 from xgpu import (
     ChainedStruct,
-    Device,
     Instance,
-    Surface,
     SurfaceDescriptor,
     surfaceDescriptor,
 )
+from xgpu.extensions import XDevice, XSurface
 
 
 def is_wayland():
@@ -82,7 +81,7 @@ class GLFWWindow:
         glfw.poll_events()
         return bool(not glfw.window_should_close(self.window))
 
-    def configure_surface(self, device: Device, format=xgpu.TextureFormat.BGRA8Unorm):
+    def configure_surface(self, device: XDevice, format=xgpu.TextureFormat.BGRA8Unorm):
         print("Configuring surface?")
         if self._surface is None:
             return
@@ -98,12 +97,12 @@ class GLFWWindow:
         )
         print("Configured surface?")
 
-    def get_surface(self, instance: Instance) -> Surface:
+    def get_surface(self, instance: Instance) -> XSurface:
         print("Getting surface?")
         if self._surface is not None:
             return self._surface
         desc = self.get_surface_descriptor()
-        self._surface = instance.createSurfaceFromDesc(desc)
+        self._surface = XSurface(instance.createSurfaceFromDesc(desc))
         print("Got surface.")
         return self._surface
 

--- a/examples/perftest_xgpu_bindbuilder.py
+++ b/examples/perftest_xgpu_bindbuilder.py
@@ -5,7 +5,7 @@ at creating bind groups than doing things the naive/explicit way.
 """
 
 import time
-from typing import Optional
+from typing import List, Optional
 
 import glfw_window
 import numpy as np
@@ -273,7 +273,7 @@ def main():
         global_bg = bind_factory.bind(global_ubuff)
         render_pass.setBindGroup(0, global_bg, [])
 
-        bgs = []
+        bgs: List[xg.BindGroup] = []
         doffset = DRAWUNIFORMS_DTYPE.itemsize
         isize = DRAWUNIFORMS_DTYPE.itemsize
         for idx in range(ROWS * COLS):

--- a/examples/tests/harness.py
+++ b/examples/tests/harness.py
@@ -114,6 +114,9 @@ class RenderHarness:
         self.name = name
         self.width, self.height = resolution
         self.instance, self.adapter, self.device, _surf = xg.helpers.startup()
+        self.instance.leak() # leak to prevent segfault on exit?
+        self.adapter.leak()
+        self.device.leak()
         texsize = xg.extent3D(width=self.width, height=self.height, depthOrArrayLayers=1)
         self.color_tex = self.device.createTexture(
             usage=xg.TextureUsage.RenderAttachment | xg.TextureUsage.CopySrc,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xgpu"
-version = "0.6.4"
+version = "0.6.5"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = ["cffi"]

--- a/xgpu/extensions.py
+++ b/xgpu/extensions.py
@@ -13,7 +13,9 @@ mapped_cb = xg.BufferMapCallback(_mapped_cb)
 
 class XAdapter(xg.Adapter):
     def __init__(self, inner: xg.Adapter):
+        """Wrap an Adapter into an XAdapter; invalidates the Adapter object"""
         super().__init__(inner._cdata)
+        inner.invalidate()
         self.properties = xg.AdapterProperties()
         self.limits = xg.SupportedLimits()
 
@@ -30,7 +32,9 @@ class XAdapter(xg.Adapter):
 
 class XDevice(xg.Device):
     def __init__(self, inner: Union[xg.Device, "XDevice"]):
+        """Wrap a Device into an XDevice; invalidates the Device object"""
         super().__init__(inner._cdata)
+        inner.invalidate()
         if isinstance(inner, XDevice):
             # TODO: wgpu-native 0.19.1.1
             # Copy limits and queue from parent to avoid ref counting issue
@@ -158,7 +162,9 @@ class XDevice(xg.Device):
 
 class XSurface(xg.Surface):
     def __init__(self, inner: xg.Surface):
+        """Wrap a Surface into an XSurface; invalidates the Surface object"""
         super().__init__(inner._cdata)
+        inner.invalidate()
         self.surf_tex = xg.SurfaceTexture()
 
     def getCurrentTexture2(self) -> xg.SurfaceTexture:

--- a/xgpu/helpers.py
+++ b/xgpu/helpers.py
@@ -150,13 +150,13 @@ def get_device(
 
 
 def startup(
-    debug=False, surface_src: Optional[Callable[[xg.Instance], xg.Surface]] = None
+    debug=False, surface_src: Optional[Callable[[xg.Instance], XSurface]] = None
 ) -> Tuple[xg.Instance, XAdapter, XDevice, Optional[XSurface]]:
     """Simplify acquisition of core objects"""
     instance = get_instance(shader_debug=debug, validation=False)
     surface: Optional[XSurface] = None
     if surface_src is not None:
-        surface = XSurface(surface_src(instance))
+        surface = surface_src(instance)
     adapter, _ = get_adapter(instance, xg.PowerPreference.HighPerformance, surface)
     device = get_device(adapter)
     return instance, adapter, device, surface


### PR DESCRIPTION
Actually releasing a `Device` seems to cause issues on some systems, so this adds a function to every opaque reference type (including `Device`) that just lets you `.leak` it (disconnect it from the Python garbage collector).