### PR TITLE
Fix double-release issue with ffi.gc

### DIFF
--- a/examples/tests/harness.py
+++ b/examples/tests/harness.py
@@ -114,9 +114,6 @@ class RenderHarness:
         self.name = name
         self.width, self.height = resolution
         self.instance, self.adapter, self.device, _surf = xg.helpers.startup()
-        self.instance.leak() # leak to prevent segfault on exit?
-        self.adapter.leak()
-        self.device.leak()
         texsize = xg.extent3D(width=self.width, height=self.height, depthOrArrayLayers=1)
         self.color_tex = self.device.createTexture(
             usage=xg.TextureUsage.RenderAttachment | xg.TextureUsage.CopySrc,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xgpu"
-version = "0.6.5"
+version = "0.6.6"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = ["cffi"]

--- a/xgpu/extensions.py
+++ b/xgpu/extensions.py
@@ -14,7 +14,7 @@ mapped_cb = xg.BufferMapCallback(_mapped_cb)
 class XAdapter(xg.Adapter):
     def __init__(self, inner: xg.Adapter):
         """Wrap an Adapter into an XAdapter; invalidates the Adapter object"""
-        super().__init__(inner._cdata)
+        self._cdata = inner._cdata
         inner.invalidate()
         self.properties = xg.AdapterProperties()
         self.limits = xg.SupportedLimits()
@@ -33,7 +33,7 @@ class XAdapter(xg.Adapter):
 class XDevice(xg.Device):
     def __init__(self, inner: Union[xg.Device, "XDevice"]):
         """Wrap a Device into an XDevice; invalidates the Device object"""
-        super().__init__(inner._cdata)
+        self._cdata = inner._cdata
         inner.invalidate()
         if isinstance(inner, XDevice):
             # TODO: wgpu-native 0.19.1.1
@@ -163,7 +163,7 @@ class XDevice(xg.Device):
 class XSurface(xg.Surface):
     def __init__(self, inner: xg.Surface):
         """Wrap a Surface into an XSurface; invalidates the Surface object"""
-        super().__init__(inner._cdata)
+        self._cdata = inner._cdata
         inner.invalidate()
         self.surf_tex = xg.SurfaceTexture()
 

--- a/xgpu/helpers.py
+++ b/xgpu/helpers.py
@@ -82,6 +82,7 @@ def get_adapter(
 
     # we have exited the loop without raising
     status, adapter, msg = stash[0]
+    stash[0] = None  # avoid keeping around a GC reference!
 
     if status != xg.RequestAdapterStatus.Success:
         raise RuntimeError(
@@ -140,6 +141,7 @@ def get_device(
 
     # we have exited the loop without raising
     status, device, msg = stash[0]
+    stash[0] = None  # avoid keeping around a GC reference!
 
     if status != xg.RequestDeviceStatus.Success:
         raise RuntimeError(


### PR DESCRIPTION
The extension classes (XAdapter, XDevice) were indirectly calling ffi.gc on an already ffi.gc'ed cdata, which *stacks the destructor twice*.