### PR TITLE
Use github's ARM runners

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
     steps:
       - uses: actions/checkout@v4
       - name: Download binaries
@@ -47,7 +47,7 @@ jobs:
           path: xgpu/
       - name: Build Wheels
         run: |
-          python -m pip install cibuildwheel==2.16.2
+          python -m pip install cibuildwheel==2.16.5
           python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xgpu"
-version = "0.8.1"
+version = "0.8.2"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = ["cffi"]
@@ -79,5 +79,4 @@ skip = ["*-win32", "*-manylinux_i686", "*musl*"]
 test-command = 'python -c "import xgpu"'
 
 [tool.cibuildwheel.macos]
-archs = ["universal2"]
 skip = ["cp36-*", "cp37-*", "pp*"]


### PR DESCRIPTION
Build and test macos_arm64 wheels and macos_x86_64 wheels separately rather than a universal2 wheel. Advantage of this is it runs the test command on the M1 runner. Also yeah I don't know why github named the ARM runners `macos-14` not `macos-m1` -_-. 